### PR TITLE
Add AudioLDM-based SFX generation

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,7 @@ pydub  # requires ffmpeg installed on the system
 python-multipart
 uuid
 requests
+audioldm @ git+https://github.com/haoheliu/AudioLDM.git
+librosa
+accelerate
+einops


### PR DESCRIPTION
## Summary
- integrate AudioLDM for generating sound effects
- overlay 1-2 AI generated SFX layers onto base audio
- log SFX prompts and return them from the API
- add AudioLDM and supporting libs to backend requirements

## Testing
- `python -m py_compile backend/main.py`
- `npm run lint` *(fails: `@typescript-eslint/no-empty-object-type` and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688baa499134832ea740636ff287af29