### PR TITLE
Add video-based SFX generation

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ audioldm @ git+https://github.com/haoheliu/AudioLDM.git
 librosa
 accelerate
 einops
+openai-whisper


### PR DESCRIPTION
## Summary
- support video uploads and store them in `uploads/`
- transcribe uploaded videos with Whisper and determine emotional tone
- generate SFX clips based on tone and return combined MP3
- expose new `/upload-video` and `/generate-sfx-from-video` endpoints
- include openai-whisper in backend requirements

## Testing
- `python -m py_compile backend/main.py`
- `python -m py_compile backend/test_audio.py`


------
https://chatgpt.com/codex/tasks/task_e_688bae4ae3ac832eae19ddc69b754cee