### PR TITLE
Integrate AudioCraft with SFX generation and new API

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -37,10 +37,10 @@ const Index = () => {
 
       const data = await response.json();
       
-      if (data.filename) {
+      if (data.file_url) {
         setGeneratedAudio({
-          url: `/download/${data.filename}`,
-          filename: data.filename,
+          url: data.file_url,
+          filename: data.file_url.split('/').pop() || 'audio.mp3',
         });
         
         toast({


### PR DESCRIPTION
## Summary
- support additional SFX prompts and return which were used
- add self-test endpoint for quick backend verification
- accept JSON payload in `/generate-audio`
- overlay provided SFX prompts when creating audio
- adjust frontend to read `file_url` from API

## Testing
- `npm run lint` *(fails: react-refresh and ts lint errors)*
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest` *(fails: ModuleNotFoundError: audiocraft)*

------
https://chatgpt.com/codex/tasks/task_e_688bb808d848832eb1d00b507d811216