### PR TITLE
Enable GPU AudioGen path with diagnostics

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,27 +1,22 @@
 FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04
-
-ENV DEBIAN_FRONTEND=noninteractive \
-    PYTHONUNBUFFERED=1 \
-    PYTHONDONTWRITEBYTECODE=1
-
+ENV DEBIAN_FRONTEND=noninteractive PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv build-essential libsndfile1 ffmpeg curl && \
-    ln -s /usr/bin/python3 /usr/bin/python && \
-    ln -s /usr/bin/pip3 /usr/bin/pip && \
+    ln -s /usr/bin/python3 /usr/bin/python && ln -s /usr/bin/pip3 /usr/bin/pip && \
     rm -rf /var/lib/apt/lists/*
 
 COPY backend /app/backend
 RUN pip install --no-cache-dir -r /app/backend/requirements.txt
+# Heavy deps must match CUDA version (here cu121)
 RUN pip install --no-cache-dir -r /app/backend/requirements-heavy.txt
 
 EXPOSE 8000
-
 HEALTHCHECK --interval=30s --timeout=5s --retries=5 \
   CMD curl -fsS http://127.0.0.1:8000/api/health >/dev/null || exit 1
 
 ENV USE_HEAVY=1
-
-CMD ["python", "-m", "uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000", "--log-level", "info"]
-
+# Optional: choose a different model size via env
+# ENV AUDIOGEN_MODEL=facebook/audiogen-large
+CMD ["python","-m","uvicorn","backend.main:app","--host","0.0.0.0","--port","8000","--log-level","info"]

--- a/backend/requirements-heavy.txt
+++ b/backend/requirements-heavy.txt
@@ -1,9 +1,4 @@
-# Heavy dependencies for optional GPU image. Installed only when
-# building the CUDA-enabled container. Versions pinned for CUDA 12.1
-# (common on RunPod). Swap the "+cu121" suffix and extra index if
-# targeting a different CUDA version.
-
-# CUDA 12.1 wheels
+# Choose CUDA 12.1 wheels (common on RunPod CUDA 12.x images). Change if your base differs.
 torch==2.3.1+cu121
 torchaudio==2.3.1+cu121
 --extra-index-url https://download.pytorch.org/whl/cu121

--- a/backend/routes/audio.py
+++ b/backend/routes/audio.py
@@ -6,6 +6,7 @@ from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 from backend.models.schemas import GenerateAudioRequest
 from backend.services.generate import generate_file
+from backend.services import heavy_audiogen
 
 router = APIRouter()
 APP_ROOT = Path(__file__).resolve().parents[2]
@@ -15,22 +16,19 @@ OUTPUT_DIR = APP_ROOT / "backend" / "output_audio"
 def generate_audio(payload: GenerateAudioRequest, request: Request):
     try:
         t0 = time.time()
-        out_path = generate_file(
-            payload.prompt,
-            payload.duration,
-            OUTPUT_DIR,
-            sample_rate=payload.sample_rate,
-            seed=payload.seed,
+        out_path, generator = generate_file(
+            payload.prompt, payload.duration, OUTPUT_DIR,
+            sample_rate=payload.sample_rate, seed=payload.seed
         )
-
         base = os.getenv("PUBLIC_BASE_URL") or str(request.headers.get("X-Public-Base-Url") or "")
         rel = f"/audio/{out_path.stem}.wav"
         url = urljoin(base.rstrip('/') + '/', rel.lstrip('/')) if base else rel
-
         elapsed = int((time.time() - t0) * 1000)
+        headers = {"X-Elapsed-Ms": str(elapsed), "X-Generator": generator}
         return JSONResponse(
-            {"ok": True, "url": url, "path": str(out_path), "elapsed_ms": elapsed},
-            headers={"X-Elapsed-Ms": str(elapsed)}
+            {"ok": True, "url": url, "path": str(out_path), "elapsed_ms": elapsed,
+             "generator": generator, "heavy_used": generator == "heavy", "heavy_error": heavy_audiogen.last_error()},
+            headers=headers
         )
     except ValidationError as ve:
         raise HTTPException(status_code=422, detail=ve.errors())

--- a/backend/services/generate.py
+++ b/backend/services/generate.py
@@ -1,93 +1,55 @@
-"""Audio generation service with optional heavy (GPU) path.
-
-This module exposes ``generate_file`` which will use the AudioGen model when
-``USE_HEAVY=1`` *and* a CUDA device is available. If the model fails to load or
-no GPU is present, the function transparently falls back to the original
-procedural synthesiser so that the demo continues to work in CPU-only
-environments.
-"""
-
-from __future__ import annotations
-
-import os
-import uuid
+import os, uuid, numpy as np, soundfile as sf
 from pathlib import Path
-from typing import Optional
-
-import numpy as np
-import soundfile as sf
-
 
 USE_HEAVY = os.getenv("USE_HEAVY", "0") == "1"
+FORCE_HEAVY = os.getenv("FORCE_HEAVY", "0") == "1"  # if set and heavy fails → raise
 SAMPLE_RATE = 44100
 
-
 def _fade(signal: np.ndarray, ms: int = 40) -> np.ndarray:
-    n = len(signal)
-    fl = max(1, int(SAMPLE_RATE * ms / 1000))
-    env_in = np.linspace(0, 1, fl)
-    env_out = np.linspace(1, 0, fl)
-    y = signal.copy()
-    y[:fl] *= env_in
-    y[-fl:] *= env_out
-    return y
-
+    n = len(signal); fl = max(1, int(SAMPLE_RATE * ms / 1000))
+    env_in  = np.linspace(0, 1, fl); env_out = np.linspace(1, 0, fl)
+    y = signal.copy(); y[:fl] *= env_in; y[-fl:] *= env_out; return y
 
 def _procedural(prompt: str, seconds: int) -> np.ndarray:
-    n = seconds * SAMPLE_RATE
-    t = np.linspace(0, seconds, n, endpoint=False)
-    seed = abs(hash(prompt)) % (2**32)
-    rng = np.random.default_rng(seed)
+    n = seconds * SAMPLE_RATE; t = np.linspace(0, seconds, n, endpoint=False)
+    seed = abs(hash(prompt)) % (2**32); rng = np.random.default_rng(seed)
     f = 110 + (seed % 300)
-    pad = (
-        0.6 * np.sin(2 * np.pi * f * t + rng.random())
-        + 0.3 * np.sin(2 * np.pi * 0.5 * f * t + rng.random())
-        + 0.2 * np.sin(2 * np.pi * 2 * f * t + rng.random())
-    )
+    pad = 0.6*np.sin(2*np.pi*f*t + rng.random()) + 0.3*np.sin(2*np.pi*0.5*f*t + rng.random()) + 0.2*np.sin(2*np.pi*2*f*t + rng.random())
     noise = rng.standard_normal(n).astype(np.float32)
-    alpha = 0.02 + (seed % 8) / 100.0
-    filt = np.zeros_like(noise, dtype=np.float32)
-    acc = 0.0
+    alpha = 0.02 + (seed % 8)/100.0
+    filt = np.zeros_like(noise, dtype=np.float32); acc = 0.0
     for i in range(n):
-        acc = alpha * noise[i] + (1 - alpha) * acc
-        filt[i] = acc
-    y = pad + 0.25 * filt
-    y = _fade(y / (np.max(np.abs(y)) + 1e-9), ms=40)
+        acc = alpha*noise[i] + (1-alpha)*acc; filt[i] = acc
+    y = pad + 0.25*filt; y = _fade(y / (np.max(np.abs(y)) + 1e-9), ms=40)
     return y.astype(np.float32)
 
-
-def _try_heavy(
-    prompt: str, seconds: int, sample_rate: int, seed: Optional[int] = None
-) -> np.ndarray:
+def _try_heavy(prompt: str, seconds: int, sample_rate: int, seed=None) -> np.ndarray:
     from backend.services import heavy_audiogen
+    return heavy_audiogen.generate_wav(prompt, seconds, sample_rate=sample_rate, seed=seed)
 
-    if not heavy_audiogen.is_available():
-        raise RuntimeError("Heavy not available")
-    return heavy_audiogen.generate_wav(
-        prompt, seconds, sample_rate=sample_rate, seed=seed
-    )
-
-
-def generate_file(
-    prompt: str,
-    duration: int,
-    output_dir: Path,
-    sample_rate: int = SAMPLE_RATE,
-    seed: Optional[int] = None,
-) -> Path:
-    """Generate audio and write it to ``output_dir`` as a WAV file."""
-
+def generate_file(prompt: str, duration: int, output_dir: Path, sample_rate: int = SAMPLE_RATE, seed=None):
+    """
+    Returns (path, generator_name). generator_name in {"heavy","procedural"}
+    """
     output_dir.mkdir(parents=True, exist_ok=True)
+    generator = "procedural"
+    audio = None
     if USE_HEAVY:
         try:
             audio = _try_heavy(prompt, duration, sample_rate, seed=seed)
-        except Exception as e:  # pragma: no cover - logging only
-            print(f"[heavy] falling back to procedural: {e}")
+            generator = "heavy"
+        except Exception as e:
+            # Log heavy failure; optionally hard-fail if FORCE_HEAVY=1
+            print(f"[generator] heavy failed, falling back: {e}")
+            from backend.services.heavy_audiogen import last_error
+            if FORCE_HEAVY:
+                raise
             audio = _procedural(prompt, duration)
+            generator = "procedural"
     else:
         audio = _procedural(prompt, duration)
+        generator = "procedural"
 
     out_path = output_dir / f"{uuid.uuid4()}.wav"
     sf.write(out_path, audio, sample_rate, subtype="PCM_16")
-    return out_path
-
+    return out_path, generator

--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -7,9 +7,11 @@ interface AudioPlayerProps {
   audioUrl?: string;
   filename?: string;
   isLoading?: boolean;
+  generator?: string;
+  heavyError?: string | null;
 }
 
-export const AudioPlayer = ({ audioUrl, filename, isLoading }: AudioPlayerProps) => {
+export const AudioPlayer = ({ audioUrl, filename, isLoading, generator, heavyError }: AudioPlayerProps) => {
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
@@ -103,7 +105,7 @@ export const AudioPlayer = ({ audioUrl, filename, isLoading }: AudioPlayerProps)
   return (
     <div className="bg-gradient-card p-6 rounded-lg border border-border space-y-4 animate-fade-in">
       <audio ref={audioRef} src={audioUrl} />
-      
+
       {/* File Info */}
       {filename && (
         <div className="flex items-center justify-between">
@@ -122,6 +124,13 @@ export const AudioPlayer = ({ audioUrl, filename, isLoading }: AudioPlayerProps)
             Download
           </Button>
         </div>
+      )}
+
+      {generator && (
+        <p className="text-xs text-muted-foreground">Generator: {generator === 'heavy' ? 'AI' : 'Fallback'}</p>
+      )}
+      {heavyError && (
+        <p className="text-[10px] text-muted-foreground opacity-70">{heavyError}</p>
       )}
 
       {/* Player Controls */}

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -62,6 +62,8 @@ const Index = () => {
   const [logs, setLogs] = useState<string[]>([]);
   const [isConsoleOpen, setIsConsoleOpen] = useState(true);
   const [lastFailedRequest, setLastFailedRequest] = useState<{prompt: string, duration: number} | null>(null);
+  const [generator, setGenerator] = useState<string | null>(null);
+  const [heavyError, setHeavyError] = useState<string | null>(null);
   const { toast } = useToast();
 
   // Logging utility function with enhanced error context
@@ -177,6 +179,8 @@ const Index = () => {
     setIsGenerating(true);
     setError(null);
     setErrorMsg("");
+    setGenerator(null);
+    setHeavyError(null);
 
     logLine(`⏳ Sending audio generation request to backend...`);
     logLine(`📝 Prompt: "${prompt.substring(0, 100)}${prompt.length > 100 ? '...' : ''}"`);
@@ -189,6 +193,8 @@ const Index = () => {
           url: data.url,
           filename: (data?.path && typeof data.path === 'string' ? data.path.split('/').pop() : '') || data.url.split('/').pop() || ''
         });
+        setGenerator(data.generator || null);
+        setHeavyError(data.heavy_error || null);
         toast({
           title: 'Audio Ready',
           description: 'Your audio has been generated.',
@@ -342,6 +348,8 @@ const Index = () => {
               audioUrl={generatedAudio?.url}
               filename={generatedAudio?.filename}
               isLoading={isLoading}
+              generator={generator || undefined}
+              heavyError={heavyError}
             />
             
             {/* Console Panel - Always visible in development, conditionally in production */}


### PR DESCRIPTION
## Summary
- add optional heavy AudioGen generator with CUDA-only requirements
- expose diagnostics endpoints and generator telemetry
- display generator type and heavy errors in UI

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689692f3a338832e8b18e70d867b8a1f