### PR TITLE
Clarify request schema and use entrypoint in GPU image

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -11,12 +11,12 @@ COPY backend /app/backend
 RUN pip install --no-cache-dir -r /app/backend/requirements.txt
 # Heavy deps must match CUDA version (here cu121)
 RUN pip install --no-cache-dir -r /app/backend/requirements-heavy.txt
+COPY docker/entrypoint.sh /app/docker/entrypoint.sh
+RUN chmod +x /app/docker/entrypoint.sh
 
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --retries=5 \
   CMD curl -fsS http://127.0.0.1:8000/api/health >/dev/null || exit 1
 
 ENV USE_HEAVY=1
-# Optional: choose a different model size via env
-# ENV AUDIOGEN_MODEL=facebook/audiogen-large
-CMD ["python","-m","uvicorn","backend.main:app","--host","0.0.0.0","--port","8000","--log-level","info"]
+ENTRYPOINT ["/app/docker/entrypoint.sh"]

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -4,7 +4,9 @@ from typing import Optional, Union
 
 class GenerateAudioRequest(BaseModel):
     prompt: str = Field(..., min_length=1, max_length=500)
-    duration: Union[int, str] = Field(..., description="Seconds, 1–120")
+    duration: Union[int, str] = Field(
+        ..., description="Seconds, 1–30 heavy, 1–120 fallback"
+    )
     seed: Optional[Union[int, str]] = None
     sample_rate: Optional[Union[int, str]] = 44100
 

--- a/backend/services/generate.py
+++ b/backend/services/generate.py
@@ -41,7 +41,6 @@ def generate_file(prompt: str, duration: int, output_dir: Path, sample_rate: int
         except Exception as e:
             # Log heavy failure; optionally hard-fail if FORCE_HEAVY=1
             print(f"[generator] heavy failed, falling back: {e}")
-            from backend.services.heavy_audiogen import last_error
             if FORCE_HEAVY:
                 raise
             audio = _procedural(prompt, duration)


### PR DESCRIPTION
## Summary
- document heavy vs fallback duration limits in request schema
- switch GPU Dockerfile to shared entrypoint script and heavy build
- remove unused import in generator service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897612b4028832e8a18b488e6730e40