### PR TITLE
ci: ensure docker hub login

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,13 +17,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to DockerHub
+      - name: Verify Docker Hub credentials
+        run: |
+          if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
+            echo "Docker Hub credentials are not set. Please add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets."
+            exit 1
+          fi
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        id: docker_login
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build (CPU) with plain logs
+        if: ${{ steps.docker_login.outcome == 'success' }}
         run: |
           set -euxo pipefail
           docker build \
@@ -32,10 +44,12 @@ jobs:
             .
 
       - name: Push (CPU)
+        if: ${{ steps.docker_login.outcome == 'success' }}
         run: |
           docker push ${{ secrets.DOCKERHUB_USERNAME }}/audio-scene-architect:latest
 
       - name: Smoke run + health (CPU)
+        if: ${{ steps.docker_login.outcome == 'success' }}
         run: |
           set -euxo pipefail
           docker run -d --rm --name test-container -p 8000:8000 \


### PR DESCRIPTION
## Summary
- verify Docker Hub credentials before building
- log in via `docker/login-action@v3` using secrets
- run build, push, and smoke test only if login succeeds

## Testing
- `python - <<'PY'
import yaml,sys
with open('.github/workflows/docker.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `docker --version` *(fails: command not found)*
- `act --version` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689773f4ecf4832ebba357252fcb6987