### PR TITLE
Harden frontend Docker build and verify in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,10 @@
 .git
+node_modules
+**/node_modules
+frontend/.cache
+**/.cache
+# Do NOT ignore source frontend; keep it in context
+# !frontend/**   # (uncomment if you previously ignored it by mistake)
 __pycache__
 **/__pycache__
 *.pyc
@@ -8,6 +14,6 @@ __pycache__
 .env
 .venv
 venv
-node_modules
 frontend/node_modules
 backend/output_audio
+dist

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+          submodules: recursive
+
+      - name: Show repo layout
+        run: |
+          set -eux
+          pwd
+          ls -la
+          echo "---- tree -L 2 (if available) ----"
+          command -v tree && tree -L 2 || true
+
+      - name: Verify frontend exists
+        run: |
+          set -eux
+          test -d frontend || (echo "Missing ./frontend directory at repo root" && exit 2)
+          test -f frontend/package.json || (echo "Missing ./frontend/package.json" && exit 3)
+          head -n 50 frontend/package.json || true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,42 @@
 # syntax=docker/dockerfile:1.6
-# ---- Frontend build (optional) ----
+
+############################
+# Frontend build (Vite)
+############################
 FROM node:20-slim AS frontend
 SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
+ARG FRONTEND_DIR=frontend
 WORKDIR /app/frontend
-COPY frontend/ ./ || true
-RUN if [[ -f package.json ]]; then \
-      echo ">>> [frontend] npm ci"; npm ci; \
-      echo ">>> [frontend] npm run build"; npm run build; \
-    else \
-      echo ">>> [frontend] No package.json; skipping build"; \
+
+# Show what we're copying (helps debug CI paths)
+RUN echo ">>> Expecting frontend dir: ${FRONTEND_DIR}"
+# Copy exactly that directory from the build context
+COPY ${FRONTEND_DIR}/ /app/frontend/
+
+# Fail early if we expected a real app but it's not here
+RUN if [[ ! -f package.json ]]; then \
+      echo "ERROR: ${FRONTEND_DIR}/package.json not found in build context. Check build context, path, or case." >&2; \
+      ls -la /app/frontend; exit 42; \
     fi
 
-# ---- Backend runtime ----
+RUN echo ">>> npm ci"; npm ci
+RUN echo ">>> npm run build"; npm run build
+
+############################
+# Backend runtime
+############################
 FROM python:3.11-slim AS runtime
 SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1
 WORKDIR /app
 
-# System deps
-RUN echo ">>> [runtime] apt-get install deps" && \
+RUN echo ">>> apt-get deps" && \
     apt-get update && apt-get install -y --no-install-recommends \
       build-essential libsndfile1 ffmpeg curl ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-# Backend code & deps
 COPY backend /app/backend
-RUN echo ">>> [runtime] pip install (requirements.txt)" && \
-    pip install --no-cache-dir -r /app/backend/requirements.txt
+RUN echo ">>> pip install reqs" && pip install --no-cache-dir -r /app/backend/requirements.txt
 
 # Build-time Python sanity checks (CPU image)
 RUN echo ">>> [runtime] Python sanity checks" && python - <<'PY'
@@ -40,17 +50,14 @@ for m in ["fastapi","uvicorn","numpy","soundfile"]:
         print("FAIL import:", m, "->", e); raise
 PY
 
-# Copy SPA if built
-RUN mkdir -p /app/frontend/dist
+# Always copy built SPA from the builder stage (if the build failed, we never reach here)
 COPY --from=frontend /app/frontend/dist /app/frontend/dist
 
-# Entrypoint
+# entrypoint + healthcheck (keep yours)
 COPY docker/entrypoint.sh /app/docker/entrypoint.sh
 RUN chmod +x /app/docker/entrypoint.sh
-
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=5 \
   CMD curl -fsS http://127.0.0.1:8000/api/health >/dev/null || exit 1
-
 ENV UVICORN_HOST=0.0.0.0 UVICORN_PORT=8000 UVICORN_LOG_LEVEL=info APP_MODULE=backend.main:app
 ENTRYPOINT ["/app/docker/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- enforce strict frontend build stage with FRONTEND_DIR arg and early failure if package.json missing
- ensure frontend sources are included in Docker context via .dockerignore
- show repo layout and verify frontend presence in CI before building image

## Testing
- `npm ci`
- `npm run build`
- `docker build --progress=plain -t audio-scene-architect:test .` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68977798bed8832eb23e925255afb7ad