### PR TITLE
Add meta and debug endpoints

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 import os, logging, sys, platform
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 from fastapi import FastAPI
@@ -51,24 +51,55 @@ async def heavy_preflight():
 def version():
     try:
         import torch
-        cuda_ok = torch.cuda.is_available()
-        cuda_ver = getattr(torch.version, "cuda", None)
-        dev = torch.cuda.get_device_name(0) if cuda_ok else None
-    except Exception as e:
-        cuda_ok, cuda_ver, dev = False, None, str(e)
+        cuda_available = torch.cuda.is_available()
+        cuda_version = getattr(torch.version, "cuda", None)
+        device_name = torch.cuda.get_device_name(0) if cuda_available else None
+    except Exception:
+        cuda_available, cuda_version, device_name = None, None, None
     try:
         from backend.services.heavy_audiogen import last_error
-        last = last_error()
-    except Exception as e:
-        last = str(e)
-    return {
-        "python": sys.version, "platform": platform.platform(),
-        "use_heavy_env": os.getenv("USE_HEAVY","0"),
-        "allow_fallback": os.getenv("ALLOW_FALLBACK",""),
-        "audiogen_model": os.getenv("AUDIOGEN_MODEL","facebook/audiogen-medium"),
-        "cuda_available": cuda_ok, "cuda_version": cuda_ver, "device_name": dev,
-        "last_heavy_error": last
-    }
+        try:
+            last = last_error()
+        except Exception as e:
+            last = str(e)
+    except Exception:
+        last = None
+    return JSONResponse(
+        {
+            "python": sys.version,
+            "platform": platform.platform(),
+            "use_heavy_env": os.getenv("USE_HEAVY", "0"),
+            "allow_fallback": os.getenv("ALLOW_FALLBACK", ""),
+            "audiogen_model": os.getenv("AUDIOGEN_MODEL", "facebook/audiogen-medium"),
+            "cuda_available": cuda_available,
+            "cuda_version": cuda_version,
+            "device_name": device_name,
+            "last_heavy_error": last,
+        }
+    )
+
+
+@app.get("/api/debug/state", tags=["debug"])
+def debug_state():
+    import importlib
+
+    def _chk(name: str) -> str:
+        try:
+            importlib.import_module(name)
+            return "ok"
+        except Exception as e:
+            return f"missing: {e}"
+
+    return JSONResponse(
+        {
+            "torch": _chk("torch"),
+            "torchaudio": _chk("torchaudio"),
+            "audiocraft": _chk("audiocraft"),
+            "USE_HEAVY": os.getenv("USE_HEAVY", "0"),
+            "ALLOW_FALLBACK": os.getenv("ALLOW_FALLBACK", ""),
+            "AUDIOGEN_MODEL": os.getenv("AUDIOGEN_MODEL", "facebook/audiogen-medium"),
+        }
+    )
 
 @app.post("/api/selftest", tags=["meta"])
 def selftest():


### PR DESCRIPTION
## Summary
- expose `/api/version` for environment and GPU/CUDA info
- add `/api/debug/state` to check torch-related package availability

## Testing
- `pytest -q`
- `docker build -f Dockerfile.gpu -t jakeypoov/audio-scene-architect:gpu .` *(fails: command not found)*
- `docker push jakeypoov/audio-scene-architect:gpu` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689782af4718832e850edac7bf30adc8