### PR TITLE
Expose diagnostics routes and log routes at startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,14 +1,11 @@
-import os, sys, platform, importlib, logging
-from fastapi.responses import HTMLResponse, JSONResponse
+import os, sys, importlib, logging
+from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 from fastapi import FastAPI
 
-from backend.routes.health import router as health_router
+from backend.routes import meta as meta_routes
 from backend.routes.audio import router as audio_router
-
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s :: %(message)s", stream=sys.stdout)
-BUILD_TAG = os.getenv("BUILD_TAG", "dev")
 
 app = FastAPI(title="SoundForge.AI", version="0.1.0")
 
@@ -17,9 +14,12 @@ OUTPUT_DIR = APP_ROOT / "backend" / "output_audio"
 FRONTEND_DIST = APP_ROOT / "frontend" / "dist"
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
-# Routers
-app.include_router(health_router)
-app.include_router(health_router, prefix="/api")
+# Build tag for verification
+BUILD_TAG = os.getenv("BUILD_TAG", "dev")
+
+# Include routers
+app.include_router(meta_routes.router, prefix="/api")
+setattr(meta_routes, "app", app)
 app.include_router(audio_router, prefix="/api")
 
 # Serve audio and SPA (or landing)
@@ -30,76 +30,28 @@ else:
     @app.get("/", include_in_schema=False)
     def _landing():
         return HTMLResponse("<h1>SoundForge.AI backend is running</h1><p>No SPA build found. See <a href='/docs'>/docs</a>.</p>")
-
-@app.get("/api/version", tags=["meta"])
-def version():
-    cuda_ok = cuda_ver = dev = None
-    try:
-        import torch
-        cuda_ok = torch.cuda.is_available()
-        cuda_ver = getattr(torch.version, "cuda", None)
-        dev = torch.cuda.get_device_name(0) if cuda_ok else None
-    except Exception:
-        pass
-    last = None
-    try:
-        heavy = importlib.import_module("backend.services.heavy_audiogen")
-        last = getattr(heavy, "last_error")()
-    except Exception:
-        pass
-    return {
-        "python": sys.version,
-        "platform": platform.platform(),
-        "build": BUILD_TAG,
-        "use_heavy_env": os.getenv("USE_HEAVY", "0"),
-        "allow_fallback": os.getenv("ALLOW_FALLBACK", ""),
-        "audiogen_model": os.getenv("AUDIOGEN_MODEL", "facebook/audiogen-medium"),
-        "cuda_available": cuda_ok,
-        "cuda_version": cuda_ver,
-        "device_name": dev,
-        "last_heavy_error": last
-    }
-
-@app.get("/api/debug/state", tags=["debug"])
-def debug_state():
-    info = {
-        "env": {
-            "USE_HEAVY": os.getenv("USE_HEAVY"),
-            "ALLOW_FALLBACK": os.getenv("ALLOW_FALLBACK"),
-            "AUDIOGEN_MODEL": os.getenv("AUDIOGEN_MODEL"),
-        },
-        "modules": {}
-    }
-    for m in ("torch","torchaudio","audiocraft"):
-        try:
-            importlib.import_module(m)
-            info["modules"][m] = "ok"
-        except Exception as e:
-            info["modules"][m] = f"missing: {e}"
-    return JSONResponse(info)
-
-@app.get("/api/debug/routes", tags=["debug"])
-def debug_routes():
-    routes = []
-    for r in app.router.routes:
-        routes.append({"path": getattr(r, "path", ""), "methods": sorted(getattr(r, "methods", ["GET"]))})
-    return {"build": BUILD_TAG, "routes": routes}
-
 @app.post("/api/debug/selftest", tags=["debug"])
 def selftest():
     try:
         from backend.services.heavy_audiogen import generate_wav
-        wav = generate_wav("leaves crunching under footsteps while walking, outdoors, dry leaves, close perspective", seconds=2, sample_rate=22050, seed=42)
+        wav = generate_wav(
+            "leaves crunching under footsteps while walking, outdoors, dry leaves, close perspective",
+            seconds=2, sample_rate=22050, seed=42
+        )
         return {"ok": True, "len": int(len(wav)), "sr": 22050, "generator": "heavy"}
     except Exception as e:
         return {"ok": False, "error": str(e)}
 
+# Log routes at startup and optionally preload heavy
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s :: %(message)s", stream=sys.stdout)
+
 @app.on_event("startup")
-async def _startup_log_and_optional_preload():
+async def _log_routes_and_preflight():
     logging.getLogger("uvicorn.error").info(f"BUILD_TAG={BUILD_TAG}")
     for r in app.router.routes:
         methods = ",".join(sorted(getattr(r, "methods", ["GET"])))
         logging.getLogger("uvicorn.error").info("ROUTE %s %s", methods, getattr(r, "path", ""))
+
     if os.getenv("USE_HEAVY","0") == "1":
         try:
             heavy = importlib.import_module("backend.services.heavy_audiogen")

--- a/backend/routes/health.py
+++ b/backend/routes/health.py
@@ -1,9 +1,0 @@
-import os
-from fastapi import APIRouter
-
-router = APIRouter()
-BUILD_TAG = os.getenv("BUILD_TAG", "dev")
-
-@router.get("/health", tags=["meta"])
-def health():
-    return {"ok": True, "build": BUILD_TAG}

--- a/backend/routes/meta.py
+++ b/backend/routes/meta.py
@@ -1,0 +1,71 @@
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+import os, sys, platform, importlib
+
+router = APIRouter()
+app = None  # will be injected by main
+
+@router.get("/health", tags=["meta"])
+def health():
+    return {"ok": True, "build": os.getenv("BUILD_TAG", "dev")}
+
+@router.get("/version", tags=["meta"])
+def version():
+    cuda_ok = cuda_ver = dev = None
+    try:
+        import torch
+        cuda_ok = torch.cuda.is_available()
+        cuda_ver = getattr(torch.version, "cuda", None)
+        dev = torch.cuda.get_device_name(0) if cuda_ok else None
+    except Exception:
+        pass
+
+    last = None
+    try:
+        heavy = importlib.import_module("backend.services.heavy_audiogen")
+        last = getattr(heavy, "last_error")()
+    except Exception:
+        pass
+
+    return JSONResponse({
+        "python": sys.version,
+        "platform": platform.platform(),
+        "build": os.getenv("BUILD_TAG","dev"),
+        "use_heavy_env": os.getenv("USE_HEAVY","0"),
+        "allow_fallback": os.getenv("ALLOW_FALLBACK",""),
+        "audiogen_model": os.getenv("AUDIOGEN_MODEL","facebook/audiogen-medium"),
+        "cuda_available": cuda_ok,
+        "cuda_version": cuda_ver,
+        "device_name": dev,
+        "last_heavy_error": last
+    })
+
+@router.get("/debug/state", tags=["debug"])
+def debug_state():
+    info = {
+        "env": {
+            "USE_HEAVY": os.getenv("USE_HEAVY"),
+            "ALLOW_FALLBACK": os.getenv("ALLOW_FALLBACK"),
+            "AUDIOGEN_MODEL": os.getenv("AUDIOGEN_MODEL"),
+        },
+        "modules": {}
+    }
+    for m in ("torch","torchaudio","audiocraft"):
+        try:
+            importlib.import_module(m)
+            info["modules"][m] = "ok"
+        except Exception as e:
+            info["modules"][m] = f"missing: {e}"
+    return JSONResponse(info)
+
+@router.get("/debug/routes", tags=["debug"])
+def debug_routes(app=...):
+    if app is ...:
+        app = globals().get("app")
+    routes = []
+    try:
+        for r in app.router.routes:  # type: ignore
+            routes.append({"path": getattr(r, "path", ""), "methods": sorted(getattr(r, "methods", ["GET"]))})
+    except Exception:
+        pass
+    return {"build": os.getenv("BUILD_TAG","dev"), "routes": routes}


### PR DESCRIPTION
## Summary
- Add `meta` router exposing `/api/health`, `/api/version`, `/api/debug/state`, and `/api/debug/routes`
- Wire router into main app and log route table on startup with optional heavy preflight
- Remove legacy `health.py` router

## Testing
- `pytest`
- `python -m py_compile backend/main.py backend/routes/meta.py backend/services/generate.py`

------
https://chatgpt.com/codex/tasks/task_e_6897892fb158832e9f1fde2224837419