### PR TITLE
Add GPU Docker image and build pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,19 +1,7 @@
 .git
-node_modules
 **/node_modules
 frontend/.cache
-**/.cache
-# Do NOT ignore source frontend; keep it in context
-# !frontend/**   # (uncomment if you previously ignored it by mistake)
 __pycache__
-**/__pycache__
 *.pyc
-*.pyo
-*.pyd
-*.swp
-.env
-.venv
-venv
-frontend/node_modules
-backend/output_audio
 dist
+

--- a/.github/workflows/build-gpu.yml
+++ b/.github/workflows/build-gpu.yml
@@ -1,0 +1,72 @@
+name: Build & Push GPU Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-gpu:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute tags
+        id: meta
+        run: |
+          TAG="jakeypoov/audio-scene-architect"
+          STAMP="$(date +%Y%m%d-%H%M%S)-${GITHUB_SHA::7}"
+          echo "tag_repo=${TAG}" >> $GITHUB_OUTPUT
+          echo "stamp=${STAMP}" >> $GITHUB_OUTPUT
+          echo "gpu_tag=${TAG}:gpu-${STAMP}" >> $GITHUB_OUTPUT
+
+      - name: Build GPU image (Dockerfile.gpu)
+        run: |
+          docker build --progress=plain \
+            -f Dockerfile.gpu \
+            --build-arg BUILD_TAG=${{ steps.meta.outputs.stamp }} \
+            -t ${{ steps.meta.outputs.tag_repo }}:gpu \
+            -t ${{ steps.meta.outputs.gpu_tag }} \
+            .
+
+      - name: Push GPU image
+        run: |
+          docker push ${{ steps.meta.outputs.tag_repo }}:gpu
+          docker push ${{ steps.meta.outputs.gpu_tag }}
+
+      - name: Print tag for RunPod (copy this)
+        run: |
+          echo "===================================="
+          echo "Use this image tag on RunPod:"
+          echo "${{ steps.meta.outputs.gpu_tag }}"
+          echo "===================================="
+
+      - name: Write tag file
+        run: echo "${{ steps.meta.outputs.gpu_tag }}" > tag.txt
+
+      - name: Upload tag as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpu-image-tag
+          path: tag.txt
+
+      - name: Job Summary
+        run: |
+          echo "### GPU image pushed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag:** \`${{ steps.meta.outputs.gpu_tag }}\`" >> $GITHUB_STEP_SUMMARY
+

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,20 @@
 # syntax=docker/dockerfile:1.6
+
+########## Frontend build (if present) ##########
+FROM node:20-slim AS frontend
+SHELL ["/bin/bash","-euxo","pipefail","-c"]
+WORKDIR /app/frontend
+# Copy the folder (must exist in repo root)
+COPY frontend/ /app/frontend/
+# If there is no package.json, create an empty dist so copy won't fail
+RUN if [[ -f package.json ]]; then \
+      echo ">>> [frontend] npm ci" && npm ci && \
+      echo ">>> [frontend] npm run build" && npm run build; \
+    else \
+      echo ">>> [frontend] no package.json; creating empty dist" && mkdir -p /app/frontend/dist; \
+    fi
+
+########## GPU Runtime ##########
 FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04
 SHELL ["/bin/bash","-euxo","pipefail","-c"]
 
@@ -11,14 +27,24 @@ ENV BUILD_TAG=${BUILD_TAG} \
 
 WORKDIR /app
 
+# System deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip python3-venv build-essential libsndfile1 ffmpeg curl git ca-certificates && \
-    ln -sf /usr/bin/python3 /usr/bin/python && ln -sf /usr/bin/pip3 /usr/bin/pip && \
+      python3 python3-pip python3-venv \
+      build-essential libsndfile1 ffmpeg curl git ca-certificates && \
+    ln -sf /usr/bin/python3 /usr/bin/python && \
+    ln -sf /usr/bin/pip3 /usr/bin/pip && \
     rm -rf /var/lib/apt/lists/*
 
+# Backend code + deps
 COPY backend /app/backend
 RUN pip install --no-cache-dir -r /app/backend/requirements.txt
 RUN pip install --no-cache-dir -r /app/backend/requirements-heavy.txt
+
+# Frontend static (if built)
+RUN mkdir -p /app/frontend/dist
+COPY --from=frontend /app/frontend/dist /app/frontend/dist
+
+# Optional: model cache dirs
 RUN mkdir -p /app/.cache/huggingface
 
 EXPOSE 8000
@@ -26,3 +52,4 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=5 \
   CMD curl -fsS http://127.0.0.1:8000/api/health >/dev/null || exit 1
 
 CMD ["python","-m","uvicorn","backend.main:app","--host","0.0.0.0","--port","8000","--log-level","info"]
+

--- a/backend/requirements-heavy.txt
+++ b/backend/requirements-heavy.txt
@@ -1,7 +1,9 @@
+# Torch + Torchaudio for CUDA 12.1
 torch==2.3.1+cu121
 torchaudio==2.3.1+cu121
 --extra-index-url https://download.pytorch.org/whl/cu121
 
+# AudioCraft stack
 audiocraft==1.3.0
 einops>=0.6
 transformers>=4.41

--- a/backend/services/generate.py
+++ b/backend/services/generate.py
@@ -2,7 +2,20 @@ import os, uuid, importlib
 import numpy as np, soundfile as sf
 from pathlib import Path
 
-USE_HEAVY = os.getenv("USE_HEAVY", "0") == "1"
+def _detect_heavy_capable() -> bool:
+    try:
+        import torch
+        from audiocraft.models import AudioGen
+        return torch.cuda.is_available()
+    except Exception:
+        return False
+
+_use_heavy_env = os.getenv("USE_HEAVY")
+if _use_heavy_env in ("0", "1"):
+    USE_HEAVY = (_use_heavy_env == "1")
+else:
+    USE_HEAVY = _detect_heavy_capable()
+
 ALLOW_FALLBACK = (os.getenv("ALLOW_FALLBACK", "").strip() == "1") if USE_HEAVY else True
 SAMPLE_RATE = 44100
 


### PR DESCRIPTION
## Summary
- add requirements-heavy.txt for CUDA and AudioCraft stack
- build GPU-ready Dockerfile with frontend assets
- auto-detect GPU heavy mode in generator
- add CI workflow to build and push GPU image, printing tag

## Testing
- `python -m py_compile backend/services/generate.py`

------
https://chatgpt.com/codex/tasks/task_e_68978f2bb51c832e930a604aa286d58e