### PR TITLE
Pin CUDA torch 2.1 heavy deps in GPU image

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -38,7 +38,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Backend code + deps
 COPY backend /app/backend
 RUN pip install --no-cache-dir -r /app/backend/requirements.txt
-RUN pip install --no-cache-dir -r /app/backend/requirements-heavy.txt
+RUN pip install --no-cache-dir \
+    --extra-index-url https://download.pytorch.org/whl/cu121 \
+    -r /app/backend/requirements-heavy.txt
 
 # Frontend static (if built)
 RUN mkdir -p /app/frontend/dist

--- a/backend/requirements-heavy.txt
+++ b/backend/requirements-heavy.txt
@@ -1,9 +1,6 @@
-# Torch + Torchaudio for CUDA 12.1
-torch==2.3.1+cu121
-torchaudio==2.3.1+cu121
+torch==2.1.0+cu121
+torchaudio==2.1.0+cu121
 --extra-index-url https://download.pytorch.org/whl/cu121
-
-# AudioCraft stack
 audiocraft==1.3.0
 einops>=0.6
 transformers>=4.41


### PR DESCRIPTION
## Summary
- pin heavy requirements to torch/torchaudio 2.1.0 with CUDA 12.1 wheels
- install heavy requirements with PyTorch extra index in GPU Dockerfile

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689791c8149c832eb2157c2b0e2400f9