### PR TITLE
Enable T5 encoder dependencies and heavy preload logging

### DIFF
--- a/backend/requirements-heavy.txt
+++ b/backend/requirements-heavy.txt
@@ -1,9 +1,16 @@
+# Torch/Torchaudio for CUDA 12.1 (compatible with Audiocraft 1.3.0)
 torch==2.1.0+cu121
 torchaudio==2.1.0+cu121
 --extra-index-url https://download.pytorch.org/whl/cu121
-audiocraft==1.3.0
-einops>=0.6
-transformers>=4.41
-accelerate>=0.30
-huggingface-hub>=0.23
 
+# AudioCraft + text encoder deps
+audiocraft==1.3.0
+transformers==4.41.2
+tokenizers>=0.14
+sentencepiece>=0.1.99
+protobuf<5
+
+# Helpers
+accelerate>=0.30
+einops>=0.6
+huggingface-hub>=0.23


### PR DESCRIPTION
## Summary
- expand heavy requirements to include transformers 4.41.2 and text encoder deps
- log Transformers version and heavy preload status on startup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68979c7c9a80832ebb6550f670c2d1c6