### PR TITLE
Add GPU base image and cache-friendly build workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,9 @@
 .git
-**/node_modules
+**/__pycache__
+**/*.pyc
+node_modules
 frontend/.cache
-__pycache__
-*.pyc
+.venv
 dist
+.DS_Store
 

--- a/.github/workflows/build-gpu-base.yml
+++ b/.github/workflows/build-gpu-base.yml
@@ -1,0 +1,29 @@
+name: Build GPU Base (rare)
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - backend/requirements.txt
+      - backend/requirements-heavy.txt
+      - Dockerfile.gpu.base
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with: { username: ${{ secrets.DOCKERHUB_USERNAME }}, password: ${{ secrets.DOCKERHUB_TOKEN }} }
+      - name: Build & push base
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.gpu.base
+          push: true
+          tags: |
+            jakeypoov/audio-scene-architect:gpu-base
+          cache-from: type=registry,ref=jakeypoov/audio-scene-architect:buildcache-base
+          cache-to: type=registry,ref=jakeypoov/audio-scene-architect:buildcache-base,mode=max
+          platforms: linux/amd64
+          provenance: false
+

--- a/.github/workflows/build-gpu.yml
+++ b/.github/workflows/build-gpu.yml
@@ -1,72 +1,44 @@
-name: Build & Push GPU Image
-
+name: Build & Push GPU App
 on:
   workflow_dispatch:
   push:
     branches: [ main ]
-
+    paths-ignore:
+      - backend/requirements.txt
+      - backend/requirements-heavy.txt
+      - Dockerfile.gpu.base
 jobs:
-  build-gpu:
+  build:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with: { username: ${{ secrets.DOCKERHUB_USERNAME }}, password: ${{ secrets.DOCKERHUB_TOKEN }} }
       - name: Compute tags
         id: meta
         run: |
-          TAG="jakeypoov/audio-scene-architect"
-          STAMP="$(date +%Y%m%d-%H%M%S)-${GITHUB_SHA::7}"
-          echo "tag_repo=${TAG}" >> $GITHUB_OUTPUT
-          echo "stamp=${STAMP}" >> $GITHUB_OUTPUT
-          echo "gpu_tag=${TAG}:gpu-${STAMP}" >> $GITHUB_OUTPUT
-
-      - name: Build GPU image (Dockerfile.gpu)
-        run: |
-          docker build --progress=plain \
-            -f Dockerfile.gpu \
-            --build-arg BUILD_TAG=${{ steps.meta.outputs.stamp }} \
-            -t ${{ steps.meta.outputs.tag_repo }}:gpu \
-            -t ${{ steps.meta.outputs.gpu_tag }} \
-            .
-
-      - name: Push GPU image
-        run: |
-          docker push ${{ steps.meta.outputs.tag_repo }}:gpu
-          docker push ${{ steps.meta.outputs.gpu_tag }}
-
-      - name: Print tag for RunPod (copy this)
-        run: |
-          echo "===================================="
-          echo "Use this image tag on RunPod:"
-          echo "${{ steps.meta.outputs.gpu_tag }}"
-          echo "===================================="
-
-      - name: Write tag file
-        run: echo "${{ steps.meta.outputs.gpu_tag }}" > tag.txt
-
-      - name: Upload tag as artifact
-        uses: actions/upload-artifact@v4
+          echo "STAMP=$(date +%Y%m%d-%H%M%S)-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+      - name: Build & push
+        uses: docker/build-push-action@v5
         with:
-          name: gpu-image-tag
-          path: tag.txt
-
-      - name: Job Summary
-        run: |
-          echo "### GPU image pushed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** \`${{ steps.meta.outputs.gpu_tag }}\`" >> $GITHUB_STEP_SUMMARY
+          context: .
+          file: Dockerfile.gpu
+          push: true
+          tags: |
+            jakeypoov/audio-scene-architect:gpu
+            jakeypoov/audio-scene-architect:gpu-${{ steps.meta.outputs.STAMP }}
+          cache-from: |
+            type=registry,ref=jakeypoov/audio-scene-architect:buildcache-gpu
+            type=registry,ref=jakeypoov/audio-scene-architect:gpu-base
+          cache-to: type=registry,ref=jakeypoov/audio-scene-architect:buildcache-gpu,mode=max
+          platforms: linux/amd64
+          build-args: |
+            BASE_IMAGE=jakeypoov/audio-scene-architect:gpu-base
+            BUILD_TAG=${{ steps.meta.outputs.STAMP }}
+          provenance: false
+      - name: Print tag
+        run: echo "Use this image: jakeypoov/audio-scene-architect:gpu-${{ steps.meta.outputs.STAMP }}"
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,76 +1,32 @@
 # syntax=docker/dockerfile:1.6
-
-########## Frontend build (if present) ##########
-FROM node:20-slim AS frontend
-SHELL ["/bin/bash","-euxo","pipefail","-c"]
-WORKDIR /app/frontend
-# Copy the folder (must exist in repo root)
-COPY frontend/ /app/frontend/
-# If there is no package.json, create an empty dist so copy won't fail
-RUN if [[ -f package.json ]]; then \
-      echo ">>> [frontend] npm ci" && npm ci && \
-      echo ">>> [frontend] npm run build" && npm run build; \
-    else \
-      echo ">>> [frontend] no package.json; creating empty dist" && mkdir -p /app/frontend/dist; \
-    fi
-
-########## GPU Runtime ##########
-FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04
+ARG BASE_IMAGE=jakeypoov/audio-scene-architect:gpu-base
+FROM ${BASE_IMAGE}
 SHELL ["/bin/bash","-euxo","pipefail","-c"]
 
 ARG BUILD_TAG=dev
-ENV BUILD_TAG=${BUILD_TAG} \
-    DEBIAN_FRONTEND=noninteractive \
-    PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1 \
-    HF_HOME=/app/.cache/huggingface \
-    TRANSFORMERS_CACHE=/app/.cache/huggingface
-
+ENV BUILD_TAG=${BUILD_TAG}
 WORKDIR /app
 
-# System deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      python3 python3-pip python3-venv \
-      build-essential libsndfile1 ffmpeg curl git ca-certificates && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    ln -sf /usr/bin/pip3 /usr/bin/pip && \
-    rm -rf /var/lib/apt/lists/*
+# Frontend build in separate stage (cached with Buildx)
+FROM node:20-slim AS frontend
+WORKDIR /app/frontend
+COPY frontend/package*.json ./
+RUN [ -f package.json ] && npm ci || true
+COPY frontend/ ./
+RUN [ -f package.json ] && npm run build || mkdir -p /app/frontend/dist
 
-# Backend code + deps
+# Back to CUDA base with deps already installed
+FROM ${BASE_IMAGE}
+WORKDIR /app
+
+# Copy backend source last so small changes don’t bust earlier layers
 COPY backend /app/backend
-RUN pip install --no-cache-dir -r /app/backend/requirements.txt
-# heavy deps (force CUDA index)
-RUN pip install --no-cache-dir \
-    --extra-index-url https://download.pytorch.org/whl/cu121 \
-    -r /app/backend/requirements-heavy.txt
 
-# Print final versions into build logs (helps debugging)
-RUN python - <<'PY'
-import torch, sys
-print(">>> Torch:", torch.__version__, "CUDA OK:", torch.cuda.is_available(), "CUDA ver:", getattr(torch.version,'cuda',None))
-try:
-    import transformers, tokenizers, sentencepiece, audiocraft, torchaudio, safetensors, huggingface_hub
-    print(">>> transformers:", transformers.__version__)
-    print(">>> tokenizers:", tokenizers.__version__)
-    import importlib.metadata as md
-    print(">>> sentencepiece:", sentencepiece.__version__ if hasattr(sentencepiece,'__version__') else 'ok')
-    print(">>> torchaudio:", torchaudio.__version__)
-    print(">>> audiocraft:", md.version('audiocraft'))
-    print(">>> safetensors:", safetensors.__version__)
-    print(">>> huggingface-hub:", huggingface_hub.__version__)
-except Exception as e:
-    print(">>> import check failed:", e, file=sys.stderr)
-PY
-
-# Frontend static (if built)
-RUN mkdir -p /app/frontend/dist
+# Copy built frontend (if any)
 COPY --from=frontend /app/frontend/dist /app/frontend/dist
-
-# Optional: model cache dirs
-RUN mkdir -p /app/.cache/huggingface
 
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --retries=5 \
   CMD curl -fsS http://127.0.0.1:8000/api/health >/dev/null || exit 1
 
 CMD ["python","-m","uvicorn","backend.main:app","--host","0.0.0.0","--port","8000","--log-level","info"]
-

--- a/Dockerfile.gpu.base
+++ b/Dockerfile.gpu.base
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1.6
+FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04
+SHELL ["/bin/bash","-euxo","pipefail","-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1 \
+    HF_HOME=/app/.cache/huggingface \
+    TRANSFORMERS_CACHE=/app/.cache/huggingface
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-pip python3-venv build-essential libsndfile1 ffmpeg curl git ca-certificates \
+  && ln -sf /usr/bin/python3 /usr/bin/python && ln -sf /usr/bin/pip3 /usr/bin/pip \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY backend/requirements.txt /app/backend/requirements.txt
+COPY backend/requirements-heavy.txt /app/backend/requirements-heavy.txt
+
+# Install light deps first (changes less often)
+RUN pip install --no-cache-dir -r /app/backend/requirements.txt
+# Install heavy CUDA deps (very large; keep cached)
+RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cu121 \
+    -r /app/backend/requirements-heavy.txt
+
+RUN python - <<'PY'
+import torch
+print("Torch:", torch.__version__, "CUDA:", getattr(torch.version,'cuda',None), "cuda.is_available:", torch.cuda.is_available())
+PY


### PR DESCRIPTION
## Summary
- add reusable CUDA base image Dockerfile
- overhaul runtime Dockerfile to leverage cached base image
- add dockerignore and GitHub workflows for base and app builds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897a58ccdd4832ea838c6e62812d5ca