### PR TITLE
feat: improve missing dependency errors for AudioGen

### DIFF
--- a/backend/services/heavy_audiogen.py
+++ b/backend/services/heavy_audiogen.py
@@ -27,6 +27,17 @@ def _load_model():
     try:
         import torch
         from audiocraft.models import AudioGen
+    except ModuleNotFoundError as e:
+        missing = e.name or str(e)
+        if missing == "T5EncoderModel" or "T5EncoderModel" in missing:
+            _LAST_ERROR = (
+                "Missing dependency 'transformers' (T5EncoderModel). "
+                "Install heavy requirements: pip install -r backend/requirements-heavy.txt"
+            )
+        else:
+            _LAST_ERROR = f"Missing dependency: {missing}"
+        raise RuntimeError(_LAST_ERROR) from e
+    try:
         _MODEL = AudioGen.get_pretrained(_DEFAULT_MODEL).to("cuda")
         _MODEL.set_generation_params(
             duration=5, use_sampling=True, top_k=250, top_p=0.0,

--- a/services/model_manager.py
+++ b/services/model_manager.py
@@ -64,6 +64,11 @@ def get_audiogen_model():
             log.error("[MODEL FAIL] Try using a larger GPU or reducing batch size")
             raise RuntimeError("❌ GPU memory insufficient for AudioGen model")
         except Exception as e:
+            if "T5EncoderModel" in str(e):
+                log.error(
+                    "[MODEL FAIL] Missing dependency 'transformers' (T5EncoderModel). "
+                    "Install heavy requirements: pip install -r backend/requirements-heavy.txt"
+                )
             log.error(f"[MODEL FAIL] AudioGen load failed: {str(e)}")
             log.error(f"[MODEL FAIL] Full error: {traceback.format_exc()}")
             log.error("[MODEL FAIL] Possible causes:")


### PR DESCRIPTION
## Summary
- provide clearer error when T5EncoderModel/transformers is missing
- hint to install heavy requirements when AudioGen dependencies are absent

## Testing
- `python -m py_compile backend/services/heavy_audiogen.py services/model_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6897b0289da0832eafb566b3c571c93a