### PR TITLE
Expose dual health endpoints and improve diagnostics

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,22 +70,30 @@ jobs:
       - name: Smoke run + health (CPU)
         if: ${{ steps.docker_login.outcome == 'success' }}
         run: |
-          set -euxo pipefail
+          set -euo pipefail
           docker run -d --name test-container -p 8000:8000 \
             -e USE_HEAVY=0 \
             ${{ secrets.DOCKERHUB_USERNAME }}/audio-scene-architect:latest
-          # wait up to 40s
+
+          echo "=== Wait for health ==="
           for i in $(seq 1 40); do
-            if curl -fsS http://127.0.0.1:8000/api/health >/dev/null; then
-              echo "Health OK on attempt $i"; break
+            if curl -fsS http://127.0.0.1:8000/health >/dev/null 2>&1 || \
+               curl -fsS http://127.0.0.1:8000/api/health >/dev/null 2>&1; then
+              echo "Health OK"; break
             fi
-            echo "Health not ready (attempt $i)"; sleep 1
+            sleep 1
           done
-          if ! curl -fsS http://127.0.0.1:8000/api/health >/dev/null; then
-            echo ">>> Container logs (last 400 lines):"
+
+          if ! (curl -fsS http://127.0.0.1:8000/health >/dev/null 2>&1 || \
+                curl -fsS http://127.0.0.1:8000/api/health >/dev/null 2>&1); then
+            echo "Health failed; dumping /api/debug/routes (if present):"
+            curl -fsS http://127.0.0.1:8000/api/debug/routes || true
+            echo "Dumping /docs (first 2000 chars):"
+            curl -fsS http://127.0.0.1:8000/docs | head -c 2000 || true
             docker logs --timestamps test-container | tail -n 400 || true
+            docker rm -f test-container || true
             exit 1
           fi
-          # Show routes
-          curl -fsS http://127.0.0.1:8000/api/_debug/routes | jq || true
+
+          curl -fsS http://127.0.0.1:8000/api/debug/routes | jq || true
           docker rm -f test-container || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ COPY --from=frontend /app/frontend/dist /app/frontend/dist
 COPY docker/entrypoint.sh /app/docker/entrypoint.sh
 RUN chmod +x /app/docker/entrypoint.sh
 EXPOSE 8000
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=5 \
-  CMD curl -fsS http://127.0.0.1:8000/api/health >/dev/null || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --retries=5 \
+  CMD sh -c 'curl -fsS http://127.0.0.1:8000/health >/dev/null || curl -fsS http://127.0.0.1:8000/api/health >/dev/null'
 ENV UVICORN_HOST=0.0.0.0 UVICORN_PORT=8000 UVICORN_LOG_LEVEL=info APP_MODULE=backend.main:app
 ENTRYPOINT ["/app/docker/entrypoint.sh"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -55,6 +55,6 @@ RUN mkdir -p /app/frontend/dist
 
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --retries=5 \
-  CMD curl -fsS http://127.0.0.1:8000/api/health >/dev/null || exit 1
+  CMD sh -c 'curl -fsS http://127.0.0.1:8000/health >/dev/null || curl -fsS http://127.0.0.1:8000/api/health >/dev/null'
 
 CMD ["python","-m","uvicorn","backend.main:app","--host","0.0.0.0","--port","8000","--log-level","info"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,10 @@
-import os, sys, platform, importlib, logging
+import os, sys, importlib, logging
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 from backend.routes.audio import router as audio_router
+from backend.routes import meta as meta_routes
 
 app = FastAPI(title="SoundForge.AI", version="0.1.0")
 
@@ -14,6 +15,10 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s :: %(message)s", stream=sys.stdout)
 BUILD_TAG = os.getenv("BUILD_TAG","dev")
+
+# Mount meta at both / and /api so /health and /api/health both work
+app.include_router(meta_routes.router, prefix="")
+app.include_router(meta_routes.router, prefix="/api")
 
 # Include routers
 app.include_router(audio_router, prefix="/api")
@@ -39,50 +44,6 @@ def selftest():
     except Exception as e:
         return {"ok": False, "error": str(e)}
 
-@app.get("/api/health", tags=["meta"])
-def health():
-    return {"ok": True, "build": BUILD_TAG}
-
-def _detected_heavy_capable():
-    try:
-        import torch
-        from audiocraft.models import AudioGen
-        return bool(torch.cuda.is_available())
-    except Exception:
-        return False
-
-@app.get("/api/version", tags=["meta"])
-def version():
-    cuda_ok = cuda_ver = dev = None
-    tf_ver = tok_ver = None
-    try:
-        import torch; cuda_ok = torch.cuda.is_available()
-        cuda_ver = getattr(torch.version, "cuda", None)
-        dev = torch.cuda.get_device_name(0) if cuda_ok else None
-    except Exception:
-        pass
-    try:
-        import transformers, tokenizers
-        tf_ver = transformers.__version__
-        tok_ver = tokenizers.__version__
-    except Exception:
-        pass
-    last = None
-    try:
-        heavy = importlib.import_module("backend.services.heavy_audiogen")
-        last = getattr(heavy, "last_error")()
-    except Exception:
-        pass
-    return {
-        "python": sys.version, "platform": platform.platform(), "build": BUILD_TAG,
-        "use_heavy_env": os.getenv("USE_HEAVY","0"), "allow_fallback": os.getenv("ALLOW_FALLBACK",""),
-        "audiogen_model": os.getenv("AUDIOGEN_MODEL","facebook/audiogen-medium"),
-        "cuda_available": cuda_ok, "cuda_version": cuda_ver, "device_name": dev,
-        "transformers_version": tf_ver, "tokenizers_version": tok_ver,
-        "detected_heavy_capable": _detected_heavy_capable(),
-        "last_heavy_error": last
-    }
-
 @app.get("/api/debug/state", tags=["debug"])
 def debug_state():
     info = {"env": {
@@ -97,21 +58,31 @@ def debug_state():
             info["modules"][m] = f"missing: {e}"
     return JSONResponse(info)
 
+@app.get("/api/debug/routes", tags=["debug"])
+def debug_routes():
+    items = []
+    for r in app.router.routes:
+        methods = sorted(getattr(r, "methods", ["GET"]))
+        items.append({"path": getattr(r, "path", ""), "methods": methods})
+    return JSONResponse(items)
+
 @app.on_event("startup")
-async def _startup_diag():
-    logging.getLogger("uvicorn.error").info(f"BUILD_TAG={BUILD_TAG}")
+async def _log_routes_and_versions():
+    import importlib
+    lg = logging.getLogger("uvicorn.error")
+    lg.info("BUILD_TAG=%s", BUILD_TAG)
+    for r in app.router.routes:
+        methods = ",".join(sorted(getattr(r, "methods", ["GET"])))
+        lg.info("ROUTE %s %s", methods, getattr(r, "path", ""))
     try:
         import transformers, tokenizers
-        logging.getLogger("uvicorn.error").info(
-            f"HF stack: transformers={transformers.__version__} tokenizers={tokenizers.__version__}"
-        )
+        lg.info("HF stack: transformers=%s tokenizers=%s", transformers.__version__, tokenizers.__version__)
     except Exception as e:
-        logging.getLogger("uvicorn.error").warning(f"HF import failed: {e}")
-    # Optional preload: do not crash on failure; we want server up for diagnostics
+        lg.warning("HF import failed: %s", e)
     if os.getenv("USE_HEAVY","0") == "1":
         try:
             heavy = importlib.import_module("backend.services.heavy_audiogen")
             getattr(heavy, "_load_model")()
-            logging.getLogger("uvicorn.error").info("✅ Heavy model loaded")
+            lg.info("✅ Heavy model loaded")
         except Exception as e:
-            logging.getLogger("uvicorn.error").warning(f"⚠️ Heavy preload failed: {e}")
+            lg.warning("⚠️ Heavy preload failed: %s", e)

--- a/backend/routes/meta.py
+++ b/backend/routes/meta.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+import os, sys, platform, importlib
+
+router = APIRouter()
+
+def _torch_info():
+    ok = ver = dev = cuda = None
+    try:
+        import torch
+        ok = True
+        cuda = torch.cuda.is_available()
+        ver = getattr(torch.version, "cuda", None)
+        dev = torch.cuda.get_device_name(0) if cuda else None
+    except Exception:
+        pass
+    return {"cuda_available": cuda, "cuda_version": ver, "device_name": dev}
+
+def _heavy_last():
+    try:
+        heavy = importlib.import_module("backend.services.heavy_audiogen")
+        return getattr(heavy, "last_error")()
+    except Exception:
+        return None
+
+def _hf_versions():
+    tf = tok = None
+    try:
+        import transformers, tokenizers
+        tf, tok = transformers.__version__, tokenizers.__version__
+    except Exception:
+        pass
+    return {"transformers_version": tf, "tokenizers_version": tok}
+
+@router.get("/health", tags=["meta"])
+def health():
+    return {"ok": True, "build": os.getenv("BUILD_TAG", "dev")}
+
+@router.get("/version", tags=["meta"])
+def version():
+    return JSONResponse({
+        "python": sys.version,
+        "platform": platform.platform(),
+        "build": os.getenv("BUILD_TAG","dev"),
+        "use_heavy_env": os.getenv("USE_HEAVY","0"),
+        "allow_fallback": os.getenv("ALLOW_FALLBACK",""),
+        "audiogen_model": os.getenv("AUDIOGEN_MODEL","facebook/audiogen-medium"),
+        **_torch_info(),
+        **_hf_versions(),
+        "last_heavy_error": _heavy_last()
+    })

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -46,10 +46,11 @@ echo "=== START UVICORN ==="
 python -m uvicorn "${APP_MODULE}" --host "${UVICORN_HOST}" --port "${UVICORN_PORT}" --log-level "${UVICORN_LOG_LEVEL}" &
 UV_PID=$!
 
-echo "=== WAIT FOR /api/health (${STARTUP_TIMEOUT}s) ==="
+echo "=== WAIT FOR /health or /api/health (${STARTUP_TIMEOUT}s) ==="
 deadline=$((SECONDS + STARTUP_TIMEOUT))
 while (( SECONDS < deadline )); do
-  if curl -fsS "http://127.0.0.1:${UVICORN_PORT}/api/health" >/dev/null; then
+  if curl -fsS "http://127.0.0.1:${UVICORN_PORT}/health" >/dev/null 2>&1 || \
+     curl -fsS "http://127.0.0.1:${UVICORN_PORT}/api/health" >/dev/null 2>&1; then
     echo "Health OK"; wait ${UV_PID}; exit $?
   fi
   if ! ps -p ${UV_PID} >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- provide path-agnostic meta router with `/health` and `/version`
- mount meta router at `/` and `/api` and log all routes on startup
- update Dockerfiles, entrypoint, and CI smoke test to try `/health` before `/api/health`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897b89a8ee0832e826d4b765f0175c4